### PR TITLE
"List" command now returns interfaces properly.

### DIFF
--- a/index.js
+++ b/index.js
@@ -219,6 +219,7 @@ function findInterfacesWin32 (targets) {
       continue
     }
   }
+  return interfaces
 }
 
 /**


### PR DESCRIPTION
This fixes the issue mentioned here: https://github.com/feross/spoof/issues/23
Just a matter of returning the "interfaces" list :)

That being said - most Windows interfaces have a space in the name, as seen here: https://i.imgur.com/IgJ2cpO.png

This causes a single interface, "Wi-Fi 2" to be read as two arguments, event when \'d, i.e. "Wi-Fi\ 2". Any advice on how to fix this one?