### PR TITLE
chore: use property shorthand to satisfy standard linter

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,10 +80,10 @@ function findInterfacesDarwin (targets) {
     }
 
     const it = {
-      address: address,
+      address,
       currentAddress: getInterfaceMAC(device),
-      device: device,
-      port: port
+      device,
+      port
     }
 
     if (targets.length === 0) {
@@ -139,10 +139,10 @@ function findInterfacesLinux (targets) {
     }
 
     const it = {
-      address: address,
+      address,
       currentAddress: getInterfaceMAC(device),
-      device: device,
-      port: port
+      device,
+      port
     }
 
     if (targets.length === 0) {
@@ -350,7 +350,7 @@ function tryWindowsKey (key, device, mac) {
 
   const networkAdapterKeyPath = new Winreg({
     hive: Winreg.HKLM,
-    key: key
+    key
   })
 
   // we need to format the MAC a bit for Windows


### PR DESCRIPTION
Summary

This PR makes a small, behavior-preserving style change to `index.js` to satisfy the Standard JS linter (object-shorthand). No functional changes were made.

Motivation

The `standard` linter reported multiple `object-shorthand` warnings in `index.js` (e.g. `address: address`, `device: device`, `port: port`). These are stylistic and can be safely rewritten using ES shorthand property syntax.

Changes

- Use property shorthand for `address`, `device`, `port` in two locations that build interface objects.
- Use shorthand for `key` in the `Winreg` constructor options object.

Files changed

- `index.js` (small, local-only formatting/idiomatic changes)

Verification / How I tested locally

Run the project tests and linter in the repo root: 
```bash
npm test
```
Expected / observed results locally: 
- Linter: object-shorthand warnings removed
- Tests: all existing tape tests pass (4/4)

Example test output (local):
``
TAP version 13
# spoof.normalize()
ok 1 should be strictly equal
ok 2 should be strictly equal
ok 3 should be strictly equal
# spoof.random
ok 4 returns valid, normalized mac addresses

1..4
# tests 4
# pass  4

# ok
```

Compatibility / Risk

This is a purely syntactic update (ES object shorthand) and is behavior-preserving. No API changes were made, and the existing tests pass locally.

Notes / follow-up

- If you prefer, I can rebase this into a feature branch instead of using `master` on my fork and open a fresh PR from that branch.
- I can also add a CI workflow to run `standard` + `tape` on PRs if desired.

Suggested reviewers / labels

- Reviewer: @feross (or any maintainer)
- Labels: chore, lint

If you want me to tweak the description, add more verification details, or change how the PR is presented (branch PR vs fork/master PR), tell me what you prefer and I will update the PR.